### PR TITLE
F - Legg til ny klient for meldekort og kall til meldekort med ny dag

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/App.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/App.kt
@@ -3,6 +3,7 @@ package no.nav.tiltakspenger.vedtak
 import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.tiltakspenger.vedtak.client.MeldekortClient
 import no.nav.tiltakspenger.vedtak.client.VedtakClient
 import no.nav.tiltakspenger.vedtak.oauth.AzureTokenProvider
 import no.nav.tiltakspenger.vedtak.rivers.events.DayHasBegunRiver
@@ -28,10 +29,14 @@ fun main() {
         securelog.error(e) { e.message }
     }
 
-    val tokenProvider = AzureTokenProvider()
+    val meldekortTokenProvider = AzureTokenProvider(config = Configuration.oauthConfig(scope = Configuration.meldekortScope()))
+    val vedtakTokenProvider = AzureTokenProvider(config = Configuration.oauthConfig(scope = Configuration.vedtakScope()))
 
     val vedtakClient = VedtakClient(
-        getToken = tokenProvider::getToken,
+        getToken = vedtakTokenProvider::getToken,
+    )
+    val meldekortClient = MeldekortClient(
+        getToken = meldekortTokenProvider::getToken,
     )
 
     RapidApplication.create(Configuration.rapidsAndRivers).apply {
@@ -48,6 +53,7 @@ fun main() {
         DayHasBegunRiver(
             rapidsConnection = this,
             vedtakClient = vedtakClient,
+            meldekortClient = meldekortClient,
         )
 
         TiltakMottattRiver(

--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/Configuration.kt
@@ -6,7 +6,6 @@ import com.natpryce.konfig.EnvironmentVariables
 import com.natpryce.konfig.Key
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
-import no.nav.tiltakspenger.vedtak.client.VedtakClient
 import no.nav.tiltakspenger.vedtak.oauth.AzureTokenProvider
 
 object Configuration {
@@ -36,6 +35,8 @@ object Configuration {
             "application.profile" to Profile.LOCAL.toString(),
             "vedtakScope" to "api://dev-gcp.tpts.tiltakspenger-vedtak/.default",
             "vedtakBaseUrl" to "http://tiltakspenger-vedtak",
+            "meldekortScope" to "api://dev-gcp.tpts.tiltakspenger-meldekort-api/.default",
+            "meldekortBaseUrl" to "http://tiltakspenger-meldekort-api",
             "logback.configurationFile" to "resources/logback.local.xml",
         ),
     )
@@ -44,6 +45,8 @@ object Configuration {
             "application.profile" to Profile.DEV.toString(),
             "vedtakScope" to "api://dev-gcp.tpts.tiltakspenger-vedtak/.default",
             "vedtakBaseUrl" to "http://tiltakspenger-vedtak",
+            "meldekortScope" to "api://dev-gcp.tpts.tiltakspenger-meldekort-api/.default",
+            "meldekortBaseUrl" to "http://tiltakspenger-meldekort-api",
         ),
     )
     private val prodProperties = ConfigurationMap(
@@ -51,6 +54,8 @@ object Configuration {
             "application.profile" to Profile.PROD.toString(),
             "vedtakScope" to "api://prod-gcp.tpts.tiltakspenger-vedtak/.default",
             "vedtakBaseUrl" to "http://tiltakspenger-vedtak",
+            "meldekortScope" to "api://prod-gcp.tpts.tiltakspenger-meldekort-api/.default",
+            "meldekortBaseUrl" to "http://tiltakspenger-meldekort-api",
         ),
     )
 
@@ -68,8 +73,14 @@ object Configuration {
 
     fun logbackConfigurationFile() = config()[Key("logback.configurationFile", stringType)]
 
+    fun vedtakScope() = config()[Key("vedtakScope", stringType)]
+    fun vedtakBaseUrl() = config()[Key("vedtakBaseUrl", stringType)]
+
+    fun meldekortScope() = config()[Key("meldekortScope", stringType)]
+    fun meldekortBaseUrl() = config()[Key("meldekortBaseUrl", stringType)]
+
     fun oauthConfig(
-        scope: String = config()[Key("vedtakScope", stringType)],
+        scope: String,
         clientId: String = config()[Key("AZURE_APP_CLIENT_ID", stringType)],
         clientSecret: String = config()[Key("AZURE_APP_CLIENT_SECRET", stringType)],
         wellknownUrl: String = config()[Key("AZURE_APP_WELL_KNOWN_URL", stringType)],
@@ -80,9 +91,13 @@ object Configuration {
         wellknownUrl = wellknownUrl,
     )
 
-    fun vedtakClientConfig(baseUrl: String = config()[Key("vedtakBaseUrl", stringType)]) =
-        VedtakClient.VedtakClientConfig(baseUrl = baseUrl)
+    fun clientConfig(baseUrl: String) =
+        ClientConfig(baseUrl = baseUrl)
 }
+
+data class ClientConfig(
+    val baseUrl: String,
+)
 
 enum class Profile {
     LOCAL, DEV, PROD

--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/client/MeldekortClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/client/MeldekortClient.kt
@@ -1,0 +1,51 @@
+package no.nav.tiltakspenger.vedtak.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.request.accept
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.preparePost
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.tiltakspenger.vedtak.ClientConfig
+import no.nav.tiltakspenger.vedtak.Configuration
+import no.nav.tiltakspenger.vedtak.defaultHttpClient
+import no.nav.tiltakspenger.vedtak.defaultObjectMapper
+import no.nav.tiltakspenger.vedtak.rivers.events.DayHasBegunEvent
+
+interface IMeldekortClient {
+    suspend fun mottaDayHasBegun(dayHasBegunEvent: DayHasBegunEvent)
+}
+
+class MeldekortClient(
+    private val clientConfig: ClientConfig = Configuration.clientConfig(baseUrl = Configuration.meldekortBaseUrl()),
+    private val objectMapper: ObjectMapper = defaultObjectMapper(),
+    private val getToken: suspend () -> String,
+    engine: HttpClientEngine? = null,
+    private val httpClient: HttpClient = defaultHttpClient(
+        objectMapper = objectMapper,
+        engine = engine,
+    ) {},
+) : IMeldekortClient {
+    companion object {
+        const val navCallIdHeader = "Nav-Call-Id"
+    }
+
+    override suspend fun mottaDayHasBegun(dayHasBegunEvent: DayHasBegunEvent) {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/meldekort/nyDag") {
+            header(navCallIdHeader, dayHasBegunEvent.date)
+            bearerAuth(getToken())
+            accept(ContentType.Application.Json)
+            contentType(ContentType.Application.Json)
+            setBody(dayHasBegunEvent)
+        }.execute()
+        when (httpResponse.status) {
+            HttpStatusCode.OK -> return
+            else -> throw RuntimeException("error (responseCode=${httpResponse.status.value}) from Meldekort")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/client/VedtakClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/client/VedtakClient.kt
@@ -11,7 +11,9 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import no.nav.tiltakspenger.vedtak.ClientConfig
 import no.nav.tiltakspenger.vedtak.Configuration
+import no.nav.tiltakspenger.vedtak.Configuration.vedtakBaseUrl
 import no.nav.tiltakspenger.vedtak.defaultHttpClient
 import no.nav.tiltakspenger.vedtak.defaultObjectMapper
 import no.nav.tiltakspenger.vedtak.rivers.events.DayHasBegunEvent
@@ -41,7 +43,7 @@ interface IVedtakClient {
 }
 
 class VedtakClient(
-    private val vedtakClientConfig: VedtakClientConfig = Configuration.vedtakClientConfig(),
+    private val clientConfig: ClientConfig = Configuration.clientConfig(baseUrl = vedtakBaseUrl()),
     private val objectMapper: ObjectMapper = defaultObjectMapper(),
     private val getToken: suspend () -> String,
     engine: HttpClientEngine? = null,
@@ -55,7 +57,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaOvergangsstønad(overgangsstønadDTO: OvergangsstønadDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/overgangsstonad") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/overgangsstonad") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -69,7 +71,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaSøknad(søknadDTO: SøknadDTO, journalpostId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/soknad") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/soknad") {
             header(navCallIdHeader, journalpostId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -83,7 +85,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaDayHasBegun(dayHasBegunEvent: DayHasBegunEvent) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/passageoftime/dayhasbegun") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/passageoftime/dayhasbegun") {
             header(navCallIdHeader, dayHasBegunEvent.date)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -97,7 +99,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaUtdatert(utdatertDTO: InnsendingUtdatert) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/innsendingutdatert") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/innsendingutdatert") {
             header(navCallIdHeader, utdatertDTO.journalpostId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -111,7 +113,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaForeldrepenger(foreldrepengerDTO: ForeldrepengerDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/foreldrepenger") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/foreldrepenger") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -125,7 +127,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaUføre(uføreDTO: UføreDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/ufore") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/ufore") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -139,7 +141,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaSkjerming(skjermingDTO: SkjermingDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/skjerming") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/skjerming") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -153,7 +155,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaTiltak(tiltakMottattDTO: TiltakMottattDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/tiltak") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/tiltak") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -167,7 +169,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaTiltak(tiltakMottattDTO: ArenaTiltakMottattDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/tiltak") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/tiltak") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -181,7 +183,7 @@ class VedtakClient(
     }
 
     override suspend fun mottaYtelser(arenaYtelserMottattDTO: ArenaYtelserMottattDTO, behovId: String) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/ytelser") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/ytelser") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -198,7 +200,7 @@ class VedtakClient(
         personopplysningerMottattDTO: PersonopplysningerMottattDTO,
         behovId: String,
     ) {
-        val httpResponse = httpClient.preparePost("${vedtakClientConfig.baseUrl}/rivers/personopplysninger") {
+        val httpResponse = httpClient.preparePost("${clientConfig.baseUrl}/rivers/personopplysninger") {
             header(navCallIdHeader, behovId)
             bearerAuth(getToken())
             accept(ContentType.Application.Json)
@@ -210,8 +212,4 @@ class VedtakClient(
             else -> throw RuntimeException("error (responseCode=${httpResponse.status.value}) from Vedtak")
         }
     }
-
-    data class VedtakClientConfig(
-        val baseUrl: String,
-    )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/oauth/TokenProvider.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/oauth/TokenProvider.kt
@@ -8,7 +8,6 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.http.Parameters
-import no.nav.tiltakspenger.vedtak.Configuration
 import no.nav.tiltakspenger.vedtak.defaultHttpClient
 import no.nav.tiltakspenger.vedtak.defaultObjectMapper
 import java.time.LocalDateTime
@@ -20,7 +19,7 @@ fun interface TokenProvider {
 class AzureTokenProvider(
     objectMapper: ObjectMapper = defaultObjectMapper(),
     engine: HttpClientEngine? = null,
-    private val config: OauthConfig = Configuration.oauthConfig(),
+    private val config: OauthConfig,
 ) : TokenProvider {
     private val azureHttpClient = defaultHttpClient(
         objectMapper = objectMapper,

--- a/src/main/kotlin/no/nav/tiltakspenger/vedtak/rivers/events/DayHasBegunRiver.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/vedtak/rivers/events/DayHasBegunRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
+import no.nav.tiltakspenger.vedtak.client.IMeldekortClient
 import no.nav.tiltakspenger.vedtak.client.IVedtakClient
 import no.nav.tiltakspenger.vedtak.rivers.loggEventVedFeil
 import no.nav.tiltakspenger.vedtak.rivers.loggEventVedInngang
@@ -18,6 +19,7 @@ data class DayHasBegunEvent(val date: LocalDate)
 
 internal class DayHasBegunRiver(
     private val vedtakClient: IVedtakClient,
+    private val meldekortClient: IMeldekortClient,
     rapidsConnection: RapidsConnection,
 ) : River.PacketListener {
 
@@ -44,6 +46,9 @@ internal class DayHasBegunRiver(
 
                 runBlocking(MDCContext()) {
                     vedtakClient.mottaDayHasBegun(
+                        DayHasBegunEvent(date = dag),
+                    )
+                    meldekortClient.mottaDayHasBegun(
                         DayHasBegunEvent(date = dag),
                     )
                 }


### PR DESCRIPTION
## Beskrivelse
Hver dag kommer det en event dayHasBegun. Denne kan brukes til å trigge meldekort 

## Kommentarer
Det måtte lages en MeldekortClient i tillegg i denne, siden det ikke fantes fra før...
Denne henger sammen med den nye routen som er lagt til i meldekort-api, og meldekort-api må deployes før denne
